### PR TITLE
Support BYTE[] as 'long string'

### DIFF
--- a/src/main/java/org/jlab/epics2web/epics/ChannelManager.java
+++ b/src/main/java/org/jlab/epics2web/epics/ChannelManager.java
@@ -111,8 +111,21 @@ public class ChannelManager {
                 short value = ((gov.aps.jca.dbr.ENUM) dbr).getEnumValue()[0];
                 builder.add("value", value);
             } else if (dbr.isBYTE()) {
-                byte value = ((gov.aps.jca.dbr.BYTE) dbr).getByteValue()[0];
-                builder.add("value", value);
+                byte[] value = ((gov.aps.jca.dbr.BYTE) dbr).getByteValue();
+                int len = value.length;
+                if (len > 1) {
+                    // epics2web generally doesn't handle arrays,
+                    // but for BYTE[] assume that data is really "long string".
+                    // Text ends at first '\0' or end of array
+                    for (int i=0; i<len; ++i)
+                        if (value[i] == 0) {
+                            len = i;
+                            break;
+                        }
+                    builder.add("value", new String(value, 0, len, "UTF-8"));
+                }
+                else
+                    builder.add("value", value[0]);
             } else {
                 String value = ((gov.aps.jca.dbr.STRING) dbr).getStringValue()[0];
                 builder.add("value", value);

--- a/src/main/java/org/jlab/epics2web/epics/ChannelMonitor.java
+++ b/src/main/java/org/jlab/epics2web/epics/ChannelMonitor.java
@@ -268,7 +268,13 @@ class ChannelMonitor implements Closeable {
             // Only create monitor on first connect, afterwards reconnect uses same old monitor
             synchronized (this) {
                 if (monitor == null) {
-                    monitor = channel.addMonitor(channel.getFieldType(), 1, Monitor.VALUE, new ChannelMonitorListener());
+                    // We generally don't handle arrays,
+                    // except for BYTE[], where we assume a "long string"
+                    int count = 1;
+                    if (channel.getFieldType().isBYTE() &&
+                        channel.getElementCount() > 1)
+                        count = channel.getElementCount();
+                    monitor = channel.addMonitor(channel.getFieldType(), count, Monitor.VALUE, new ChannelMonitorListener());
                     context.flushIO();
                 }
             }


### PR DESCRIPTION
epics2web and thus WebEDM generally don't support array values for plots etc., but BYTE arrays are often used as "long strings" from a longstringIn/Out record, a waveform record with FTVL=CHAR, or link fields accessed with a '$' suffix to overcome the 40 character length limitation of the EPICS string data type.
This PR causes epics2web to treat BYTE arrays as strings, so WebEDM can now display data from longstringIn/Out, CHAR waveforms and xxx.INP$ or xxx.OUT$ links. 