### PR TITLE
Restart/Logging/Debug tweaks

### DIFF
--- a/src/main/java/org/jlab/epics2web/Application.java
+++ b/src/main/java/org/jlab/epics2web/Application.java
@@ -62,6 +62,7 @@ public class Application implements ServletContextListener {
         return writerExecutor.submit(new Runnable() {
             @Override
             public void run() {
+                final String id = session.getId() + " / " + session.getUserProperties().get("ip");
                 final ArrayBlockingQueue<String> writequeue = (ArrayBlockingQueue<String>) session.getUserProperties().get("writequeue");
                 try {
                     while (true) {
@@ -72,7 +73,7 @@ public class Application implements ServletContextListener {
                                 try {
                                     session.getBasicRemote().sendText(msg);
                                 } catch (IllegalStateException | IOException e) { // If session closes between time session.isOpen() and sentText(msg) then you'll get this exception.  Not an issue.
-                                    LOGGER.log(Level.FINEST, "Unable to send message: ", e);
+                                    LOGGER.log(Level.FINEST, "Unable to send message to " + id, e);
 
                                     if (!session.isOpen()) {
                                         LOGGER.log(Level.FINEST, "Session closed after write exception; shutting down write thread");
@@ -81,12 +82,12 @@ public class Application implements ServletContextListener {
                                 }
                             }
                         } else {
-                            LOGGER.log(Level.FINEST, "Session closed; shutting down write thread");
+                            LOGGER.log(Level.FINEST, "Session {0} closed; shutting down write thread", id);
                             break;
                         }
                     }
                 } catch (InterruptedException e) {
-                    LOGGER.log(Level.FINEST, "Shutting down writer thread as requested", e);
+                    LOGGER.log(Level.FINEST, "Shutting down {0} writer thread as requested by InterruptException", id);
                 }
             }
         });

--- a/src/main/java/org/jlab/epics2web/controller/WebConsole.java
+++ b/src/main/java/org/jlab/epics2web/controller/WebConsole.java
@@ -8,9 +8,9 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import javax.websocket.Session;
 import org.jlab.epics2web.Application;
 import org.jlab.epics2web.epics.ChannelMonitor;
+import org.jlab.epics2web.websocket.SessionInfo;
 import org.jlab.epics2web.websocket.WebSocketSessionManager;
 import org.jlab.epics2web.epics.ChannelManager;
 
@@ -40,7 +40,7 @@ public class WebConsole extends HttpServlet {
         
 
         Map<String, ChannelMonitor> monitorMap = channelManager.getMonitorMap();
-        Map<Session, Set<String>> clientMap = sessionManager.getClientMap();
+        Map<SessionInfo, Set<String>> clientMap = sessionManager.getClientMap();
         
         request.setAttribute("monitorMap", monitorMap);
         request.setAttribute("clientMap", clientMap);

--- a/src/main/java/org/jlab/epics2web/epics/ChannelManager.java
+++ b/src/main/java/org/jlab/epics2web/epics/ChannelManager.java
@@ -382,7 +382,7 @@ public class ChannelManager {
      *
      * @return The listener to PVs map
      */
-    public Map<PvListener, Set<String>> getClientMap() {
+    public Map<PvListener, Set<String>> getListenerMap() {
         return Collections.unmodifiableMap(clientMap);
     }
 }

--- a/src/main/java/org/jlab/epics2web/epics/ChannelManager.java
+++ b/src/main/java/org/jlab/epics2web/epics/ChannelManager.java
@@ -130,7 +130,9 @@ public class ChannelManager {
 
     public void addValueToJSON(JsonObjectBuilder builder, DBR dbr) {
         try {
-            if (dbr.isDOUBLE()) {
+            if(dbr == null) {
+                builder.addNull("value"); // null happens on restart?
+            } else if (dbr.isDOUBLE()) {
                 double value = ((gov.aps.jca.dbr.DOUBLE) dbr).getDoubleValue()[0];
                 if (Double.isFinite(value)) {
                     builder.add("value", value);

--- a/src/main/java/org/jlab/epics2web/epics/ChannelMonitor.java
+++ b/src/main/java/org/jlab/epics2web/epics/ChannelMonitor.java
@@ -266,7 +266,7 @@ public class ChannelMonitor implements Closeable {
                                 handleRegularConnectionOrReconnect();
                             }
                         } else {
-                            LOGGER.log(Level.FINE, "Notifying clients of disconnect from channel: {0}", pv);
+                            LOGGER.log(Level.FINEST, "Notifying clients of disconnect from channel: {0}", pv);
 
                             state.set(MonitorState.DISCONNECTED);
                             notifyPvInfoAll(false);

--- a/src/main/java/org/jlab/epics2web/websocket/SessionInfo.java
+++ b/src/main/java/org/jlab/epics2web/websocket/SessionInfo.java
@@ -1,0 +1,43 @@
+package org.jlab.epics2web.websocket;
+
+/**
+ * This class provides a snapshot of websocket information that will not throw Exceptions if you try to interrogate it
+ * after the session happens to have closed.  There is a race condition if you hand a list of javax.websocket.Session
+ * objects to a debug console for example as if the session happens to close between the time you return it and the
+ * time the debug console calls the userProperties method for example you get an exception.
+ */
+public class SessionInfo {
+    private String id;
+    private String ip;
+    private String name;
+    private String agent;
+    private long droppedMessageCount;
+
+    public SessionInfo(String id, String ip, String name, String agent, long droppedMessageCount) {
+        this.id = id;
+        this.ip = ip;
+        this.name = name;
+        this.agent = agent;
+        this.droppedMessageCount = droppedMessageCount;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getIp() {
+        return ip;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getAgent() {
+        return agent;
+    }
+
+    public long getDroppedMessageCount() {
+        return droppedMessageCount;
+    }
+}

--- a/src/main/webapp/WEB-INF/views/console.jsp
+++ b/src/main/webapp/WEB-INF/views/console.jsp
@@ -49,11 +49,11 @@
                 <c:forEach items="${clientMap}" var="client">
                     <tr>
                         <td><c:out value="${client.key.id}"/></td>
-                        <td><c:out value="${client.key.userProperties.ip eq null ? client.key.remoteAddr : client.key.userProperties.ip}"/></td>
-                        <td><c:out value="${client.key.userProperties.agent}"/></td>
-                        <td><c:out value="${client.key.userProperties.name}"/></td>
+                        <td><c:out value="${client.key.ip}"/></td>
+                        <td><c:out value="${client.key.agent}"/></td>
+                        <td><c:out value="${client.key.name}"/></td>
                         <td>(${client.value == null ? '0' : client.value.size()}) <c:out value="${client.value}"/></td>
-                        <td><fmt:formatNumber value="${client.key.userProperties.droppedMessageCount}"/></td>
+                        <td><fmt:formatNumber value="${client.key.droppedMessageCount}"/></td>
                     </tr>
                 </c:forEach>
             </tbody>


### PR DESCRIPTION
Watching log files and the web console after deploying version [1.17.0](https://github.com/JeffersonLab/epics2web/releases/tag/v1.17.0) revealed some issues:
- On restart DBR can be null so instead of sending empty string just forward null.
- There is a race condition in that javax.websocket.Session object will throw an Exception if you try to interrogate it after it is closed.  This means on the debug screen if a client goes away right after the list of sessions is forwarded to the console and then the console calls methods on the session looking for ID, IP, User Agent, etc. then console crashes.
- Some log message log levels need adjusting and session ID info needs to be included
- Re-enable dropped message logging, but only log at thresholds to avoid flooding the log.